### PR TITLE
move pop up messages to the bottom left

### DIFF
--- a/src/css/angular/angular-growl.less
+++ b/src/css/angular/angular-growl.less
@@ -1,8 +1,8 @@
 .growl {
     position: fixed;
-    top: @nav-height + @std-padding;
-    right: 10px;
-    float: right;
+    bottom: 0;
+    left: 10px;
+    float: left;
     width: 250px;
     z-index: 200000;
 }


### PR DESCRIPTION
replace the apple growl ui pattern with the google toast ui pattern because the google pattern is more familiar in web interfaces

![screen shot 2015-10-22 at 10 59 28 am](https://cloud.githubusercontent.com/assets/1409121/10674283/faabf8de-78ae-11e5-9a82-27904592bb17.png)

resolves #70 